### PR TITLE
remove isolated generators along with isolated nodes

### DIFF
--- a/SourceScripts/c3_create_scenarios_and_models.R
+++ b/SourceScripts/c3_create_scenarios_and_models.R
@@ -45,14 +45,29 @@ if (exists('isolated.nodes.to.remove.args.list')) {
             # read in isolated nodes to remove file and change it to a veector
             isolated.nodes.to.remove[,Units:="0"]
             
+            # turn off generators on isolated nodes
+            isolated.generators.to.remove = generator.data.table[Node %in%
+                                            isolated.nodes.to.remove[,Node.Name],
+                                            .(Generator)]
+            
+            isolated.generators.to.remove[,Units:="0"]
+            
             if(!is.na(cur.scenario)){
                 import_properties(isolated.nodes.to.remove, names.col = "Node.Name", 
                                         object.class = "Node", collection.name =  "Nodes",
                                         scenario.name = cur.scenario)
+              
+                import_properties(isolated.generators.to.remove, names.col = "Generator",
+                                      object.class = "Generator", collection.name =  "Generators",
+                                      scenario.name = cur.scenario)
             } else {
                 import_properties(isolated.nodes.to.remove, names.col = "Node.Name", 
                                         object.class = "Node", collection.name =  "Nodes",
                                         overwrite = TRUE)
+              
+                import_properties(isolated.generators.to.remove, names.col = "Generator",
+                                      object.class = "Generator", collection.name =  "Generators",
+                                      overwrite = TRUE)
             }
             
             # recalculate relevant LPFs for other nodes 


### PR DESCRIPTION
changed the "Remove isolated nodes" scenario to also turn off generators located on isolated nodes. 

should we also add in a check to turn off storage, purchasers, batteries, other objects?