### PR TITLE
Recognize SQL queries that start with "WITH" as well as "SELECT"

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Note: **PIDG/driver.R** can also be called from the command line, using a format
 
 ### Input parameter file options
 
-The input parameter file tells PIDG where to look for data and how to process it. Data can be stored in a PSS/E (version 31) .raw file, .csv files, or in a postgresql database. Pointers to data are defined in the input parameters file in one of several lists, and which list data is read in in will determine how PIDG will treat the data. This is a list of possible variables that can be defined as input parameters. Note: below, "data pointer" means either a path to a csv file, relative to the variable `inputfiles.dir` or a SQL query (beginning with "SELECT") that will be sent to the postgresql database defined by `inputfiles.db`. Unless otherwise specified, if a variable is undefined, it will be ignored.
+The input parameter file tells PIDG where to look for data and how to process it. Data can be stored in a PSS/E (version 31) .raw file, .csv files, or in a postgresql database. Pointers to data are defined in the input parameters file in one of several lists, and which list data is read in in will determine how PIDG will treat the data. This is a list of possible variables that can be defined as input parameters. Note: below, "data pointer" means either a path to a csv file, relative to the variable `inputfiles.dir` or a SQL query (beginning with "SELECT" or "WITH") that will be sent to the postgresql database defined by `inputfiles.db`. Unless otherwise specified, if a variable is undefined, it will be ignored.
 
 switches:
 * `plexos.version`: numeric, can be 6 or 7. Defaults to 7 if undefined. This determine the column names in the Properties tab of the final Excel workbook, since these are different between PLEXOS 6.xx and 7.xx.

--- a/SourceScripts/functions.R
+++ b/SourceScripts/functions.R
@@ -124,7 +124,7 @@ read_data <- function(to_data, dir = inputfiles.dir, con = conn,
                 to.return <- NA
             }
             
-        } else if (startsWith(tolower(to_data), "select")) {
+        } else if (grepl("^(select|with)",tolower(to_data))) {
             
             # pull data from a db if a connection exists
             if (exists("conn")) {


### PR DESCRIPTION
This is to make PIDG recognize strings that start with auxiliary queries as valid SQL.